### PR TITLE
fix(git): if var_color is available, execute it

### DIFF
--- a/git
+++ b/git
@@ -5,8 +5,8 @@ GIT_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 git_conventionnal_commits() {
   if [[ $(type -t "var_color") != "function" ]]; then
     source "${GIT_SCRIPT_DIR}/meta" && meta_init "var"
-    var_color
   fi
+  var_color
 
   declare -gA CONVENTIONAL_COMMIT_SCOPES
   CONVENTIONAL_COMMIT_SCOPES['build']='Changes that affect the build system or external dependencies'


### PR DESCRIPTION
Hello,

I've got a small behavior when work on [ViBiOh/kmux](https://github.com/ViBiOh/kmux/pull/4) when I commit

<!-- not a michel -->
```shell
./git: line 18: RED: unbound variable
./git: line 19: RED: unbound variable
./git: line 20: RED: unbound variable
./git: line 21: RED: unbound variable
[feat_pods_logs 2df959b] feat(logs): add pods by name
 Date: Wed Aug 17 22:32:57 2022 +0200
 2 files changed, 7 insertions(+)
```